### PR TITLE
dev-util/beekeeper-studio-bin with USE appindicator needs slot number for dev-libs/libappindicator changed to 2 instead of 3

### DIFF
--- a/dev-util/beekeeper-studio-bin/beekeeper-studio-bin-5.0.9.ebuild
+++ b/dev-util/beekeeper-studio-bin/beekeeper-studio-bin-5.0.9.ebuild
@@ -40,7 +40,7 @@ RDEPEND="app-accessibility/at-spi2-atk:2[${MULTILIB_USEDEP}]
   x11-libs/libXScrnSaver:0[${MULTILIB_USEDEP}]
   x11-libs/libXtst:0[${MULTILIB_USEDEP}]
   x11-libs/pango:0[${MULTILIB_USEDEP}]
-  appindicator? ( dev-libs/libappindicator:3[${MULTILIB_USEDEP}] )"
+  appindicator? ( dev-libs/libappindicator:2[${MULTILIB_USEDEP}] )"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
dev-util/beekeeper-studio-bin relies on dev-libs/libappindicator when USE flag appindicator is enabled.  The only version of dev-libs/libappindicator I have is from the steam-overlay and uses slot number 2.