### PR TITLE
gui-libs/libadwaita: Update deps

### DIFF
--- a/gui-libs/libadwaita/libadwaita-1.7.2-r1.ebuild
+++ b/gui-libs/libadwaita/libadwaita-1.7.2-r1.ebuild
@@ -19,8 +19,8 @@ IUSE="+introspection test +vala"
 REQUIRED_USE="vala? ( introspection )"
 
 RDEPEND="
-	>=dev-libs/glib-2.76:2
-	>=gui-libs/gtk-4.13.4:4[introspection?]
+	>=dev-libs/glib-2.80:2
+	>=gui-libs/gtk-4.17.5:4[introspection?]
 	dev-libs/appstream:=
 	dev-libs/fribidi
 	introspection? ( >=dev-libs/gobject-introspection-1.54:= )


### PR DESCRIPTION
From /src/meson.build update minimal deps and fix build

<pre>
>>> Configuring source in /var/tmp/portage/gui-libs/libadwaita-1.7.2/work/libadwaita-1.7.2 ...
meson setup -Db_lto=false --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc --wrap-mode nodownload --build.pkg-config-path /var/tmp/portage/gui-libs/libadwaita-1.7.2/temp/pkgconfig:/var/tmp/portage/gui-libs/libadwaita-1.7.2/temp/python3.13/pkgconfig:/usr/share/pkgconfig --pkg-config-path /var/tmp/portage/gui-libs/libadwaita-1.7.2/temp/pkgconfig:/var/tmp/portage/gui-libs/libadwaita-1.7.2/temp/python3.13/pkgconfig:/usr/share/pkgconfig --native-file /var/tmp/portage/gui-libs/libadwaita-1.7.2/temp/meson.x86_64-pc-linux-gnu.amd64.ini -Db_pch=false -Dwerror=false -Dbuildtype=plain --wrap-mode nofallback -Dprofiling=false -Dintrospection=enabled -Dvapi=true -Dgtk_doc=false -Dtests=false -Dexamples=false /var/tmp/portage/gui-libs/libadwaita-1.7.2/work/libadwaita-1.7.2 /var/tmp/portage/gui-libs/libadwaita-1.7.2/work/libadwaita-1.7.2-build The Meson build system
Version: 1.8.0
Source dir: /var/tmp/portage/gui-libs/libadwaita-1.7.2/work/libadwaita-1.7.2 Build dir: /var/tmp/portage/gui-libs/libadwaita-1.7.2/work/libadwaita-1.7.2-build Build type: native build
DEPRECATION: Option 'gtk_doc' is replaced by 'documentation' Project name: libadwaita
Project version: 1.7.2
C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 14.2.1 "x86_64-pc-linux-gnu-gcc (Gentoo 14.2.1_p20241221 p7) 14.2.1 20241221") C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.44 Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wcast-align: YES Compiler for C supports arguments -Wdate-time: YES Compiler for C supports arguments -Werror=format-security -Werror=format=2: YES Compiler for C supports arguments -Wendif-labels: YES Compiler for C supports arguments -Werror=incompatible-pointer-types: YES Compiler for C supports arguments -Werror=missing-declarations: YES Compiler for C supports arguments -Werror=overflow: YES Compiler for C supports arguments -Werror=return-type: YES Compiler for C supports arguments -Werror=shift-count-overflow: YES Compiler for C supports arguments -Werror=shift-overflow=2: YES Compiler for C supports arguments -Werror=implicit-fallthrough=3: YES Compiler for C supports arguments -Wformat-nonliteral: YES Compiler for C supports arguments -Wformat-security: YES Compiler for C supports arguments -Winit-self: YES Compiler for C supports arguments -Wmaybe-uninitialized: YES Compiler for C supports arguments -Wmissing-field-initializers: YES Compiler for C supports arguments -Wmissing-include-dirs: YES Compiler for C supports arguments -Wmissing-noreturn: YES Compiler for C supports arguments -Wnested-externs: YES Compiler for C supports arguments -Wno-missing-field-initializers: YES Compiler for C supports arguments -Wno-sign-compare: YES Compiler for C supports arguments -Wno-strict-aliasing: YES Compiler for C supports arguments -Wno-unused-parameter: YES Compiler for C supports arguments -Wold-style-definition: YES Compiler for C supports arguments -Wpointer-arith: YES Compiler for C supports arguments -Wredundant-decls: YES Compiler for C supports arguments -Wshadow: YES
Compiler for C supports arguments -Wstrict-prototypes: YES Compiler for C supports arguments -Wswitch-default: YES Compiler for C supports arguments -Wswitch-enum: YES Compiler for C supports arguments -Wtype-limits: YES Compiler for C supports arguments -Wundef: YES
Compiler for C supports arguments -Wunused-function: YES Compiler for C supports arguments -Wfloat-equal: YES Program sassc found: YES (/usr/bin/sassc)
Found pkg-config: YES (/usr/bin/x86_64-pc-linux-gnu-pkg-config) 2.4.3 Build-time dependency gio-2.0 found: YES 2.82.5
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources) Dependency gio-2.0 found: YES 2.82.5 (cached)
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources) Configuring adw-version.h using configuration
Build-time dependency glib-2.0 found: YES 2.82.5
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums) Dependency glib-2.0 found: YES 2.82.5 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums) Dependency glib-2.0 found: YES 2.82.5 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums) Dependency glib-2.0 found: YES 2.82.5 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums) Dependency glib-2.0 found: YES 2.82.5 (cached)
Program /usr/bin/glib-genmarshal found: YES (/usr/bin/glib-genmarshal) Program gen-public-types.py found: YES (/usr/bin/python3.12 /var/tmp/portage/gui-libs/libadwaita-1.7.2/work/libadwaita-1.7.2/src/gen-public-types.py) Dependency gio-2.0 found: YES 2.82.5 (cached)
Dependency gtk4 found: NO. Found 4.16.12 but need: '>= 4.17.5' Found CMake: /usr/bin/cmake (3.31.5)
Run-time dependency gtk4 found: NO (tried pkgconfig and cmake) Not looking for a fallback subproject for the dependency gtk4 because: Use of fallback dependencies is disabled.

src/meson.build:315:10: ERROR: Dependency 'gtk4' is required but not found.

</pre>