### PR TITLE
gnome-base/gnome-control-center: Update deps

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-48.1-r1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-48.1-r1.ebuild
@@ -33,9 +33,9 @@ DEPEND="
 	x11-libs/gtk+:3
 	>=net-libs/gnome-online-accounts-3.52.0:=
 	>=media-libs/libpulse-2.0[glib]
-	>=gui-libs/gtk-4.11.2:4[X,wayland=]
-	>=gui-libs/libadwaita-1.4_alpha:1
-	>=sys-apps/accountsservice-0.6.39
+	>=gui-libs/gtk-4.15.2:4[X,wayland=]
+	>=gui-libs/libadwaita-1.7_alpha:1
+	>=sys-apps/accountsservice-23.11.69
 	>=x11-misc/colord-0.1.34:0=
 	>=x11-libs/gdk-pixbuf-2.23.0:2
 	>=dev-libs/glib-2.76.6:2
@@ -86,7 +86,7 @@ RDEPEND="${DEPEND}
 		app-admin/system-config-printer
 		net-print/cups-pk-helper
 	)
-	gnome-extra/tecla
+	>=gnome-extra/tecla-47.0
 	wayland? ( dev-libs/libinput )
 	!wayland? (
 		>=x11-drivers/xf86-input-libinput-0.19.0


### PR DESCRIPTION
From /meson.build fix build

<pre>
>>> Configuring source in /var/tmp/portage/gnome-base/gnome-control-center-48.1/work/gnome-control-center-48.1 ...
meson setup -Db_lto=false --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc --wrap-mode nodownload --build.pkg-config-path /var/tmp/portage/gnome-base/gnome-control-center-48.1/temp/python3.12/pkgconfig:/usr/share/pkgconfig --pkg-config-path /var/tmp/portage/gnome-base/gnome-control-center-48.1/temp/python3.12/pkgconfig:/usr/share/pkgconfig --native-file /var/tmp/portage/gnome-base/gnome-control-center-48.1/temp/meson.x86_64-pc-linux-gnu.amd64.ini -Db_pch=false -Dwerror=false -Dbuildtype=plain -Ddeprecated-declarations=disabled -Ddocumentation=true -Dlocation-services=enabled -Dibus=true -Dprivileged_group=wheel -Dsnap=false -Dtests=false -Dmalcontent=false -Ddistributor_logo=/usr/share/pixmaps/gnome-control-center-gentoo-logo.svg -Ddark_mode_distributor_logo=/usr/share/pixmaps/gnome-control-center-gentoo-logo-dark.svg /var/tmp/portage/gnome-base/gnome-control-center-48.1/work/gnome-control-center-48.1 /var/tmp/portage/gnome-base/gnome-control-center-48.1/work/gnome-control-center-48.1-build The Meson build system
Version: 1.8.0
Source dir: /var/tmp/portage/gnome-base/gnome-control-center-48.1/work/gnome-control-center-48.1 Build dir: /var/tmp/portage/gnome-base/gnome-control-center-48.1/work/gnome-control-center-48.1-build Build type: native build
Project name: gnome-control-center
Project version: 48.1
C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 14.2.1 "x86_64-pc-linux-gnu-gcc (Gentoo 14.2.1_p20241221 p7) 14.2.1 20241221") C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.44 Host machine cpu family: x86_64
Host machine cpu: x86_64
Program python3 found: YES (/var/tmp/portage/gnome-base/gnome-control-center-48.1/temp/python3.12/bin/python3)

Executing subproject gvc

gvc| Project name: gvc
gvc| Project version: undefined
gvc| C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 14.2.1 "x86_64-pc-linux-gnu-gcc (Gentoo 14.2.1_p20241221 p7) 14.2.1 20241221") gvc| C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.44 gvc| Found pkg-config: YES (/usr/bin/x86_64-pc-linux-gnu-pkg-config) 2.4.3 gvc| Build-time dependency glib-2.0 found: YES 2.82.5 gvc| Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums) gvc| Dependency glib-2.0 found: YES 2.82.5 (cached) gvc| Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums) gvc| Run-time dependency gio-2.0 found: YES 2.82.5 gvc| Run-time dependency gobject-2.0 found: YES 2.82.5 gvc| Run-time dependency libpulse found: YES 17.0
gvc| Run-time dependency libpulse-mainloop-glib found: YES 17.0 gvc| Configuring config.h using configuration
gvc| Build targets in project: 3
gvc| Subproject gvc finished.

Run-time dependency gtk4 found: YES 4.16.12
Dependency libadwaita-1 found: NO. Found 1.6.2 but need: '>= 1.7.alpha' Found CMake: /usr/bin/cmake (3.31.5)
Run-time dependency libadwaita-1 found: NO (tried pkgconfig and cmake) Dependency libadwaita-1 found: NO. Found 1.6.2 but need: '>= 1.7.alpha' Run-time dependency libadwaita-1 found: NO (tried pkgconfig and cmake) Looking for a fallback subproject for the dependency libadwaita-1 ERROR: Subproject libadwaita is buildable: NO

meson.build:154:19: ERROR: Automatic wrap-based subproject downloading is disabled </pre>