### PR TITLE
gui-libs/gtk: Update deps

### DIFF
--- a/gui-libs/gtk/gtk-4.19.0-r1.ebuild
+++ b/gui-libs/gtk/gtk-4.19.0-r1.ebuild
@@ -20,11 +20,11 @@ KEYWORDS="~alpha amd64 arm arm64 ~loong ppc ppc64 ~riscv sparc x86"
 
 # TODO: Optional gst build dep on >=gst-plugins-base-1.23.1, so depend on it once we can
 COMMON_DEPEND="
-	>=dev-libs/glib-2.76.0:2
-	>=x11-libs/cairo-1.17.6[aqua?,glib,svg(+),X?]
-	>=x11-libs/pango-1.50.0[introspection?]
+	>=dev-libs/glib-2.82.0:2
+	>=x11-libs/cairo-1.18.2[aqua?,glib,svg(+),X?]
+	>=x11-libs/pango-1.56.0[introspection?]
 	>=dev-libs/fribidi-1.0.6
-	>=media-libs/harfbuzz-2.6.0:=
+	>=media-libs/harfbuzz-8.4.0:=
 	>=x11-libs/gdk-pixbuf-2.30:2[introspection?]
 	media-libs/libpng:=
 	media-libs/tiff:=
@@ -34,7 +34,7 @@ COMMON_DEPEND="
 	app-text/iso-codes
 	x11-misc/shared-mime-info
 
-	cloudproviders? ( net-libs/libcloudproviders )
+	cloudproviders? ( >=net-libs/libcloudproviders-0.3.1 )
 	colord? ( >=x11-misc/colord-0.1.9:0= )
 	cups? ( >=net-print/cups-2.0 )
 	examples? ( gnome-base/librsvg:2 )
@@ -46,10 +46,10 @@ COMMON_DEPEND="
 			>=media-libs/gst-plugins-base-1.24.0:1.0[opengl]
 		)
 	)
-	introspection? ( >=dev-libs/gobject-introspection-1.76:= )
+	introspection? ( >=dev-libs/gobject-introspection-1.84:= )
 	vulkan? ( >=media-libs/vulkan-loader-1.3:= )
 	wayland? (
-		>=dev-libs/wayland-1.21.0
+		>=dev-libs/wayland-1.41.0
 		>=dev-libs/wayland-protocols-1.31
 		media-libs/mesa[wayland]
 		>=x11-libs/libxkbcommon-0.2


### PR DESCRIPTION
From /meson.build fix build

<pre>
meson setup -Db_lto=false --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc --wrap-mode nodownload --build.pkg-config-path /var/tmp/portage/gui-libs/gtk-4.19.0/temp/python3.12/pkgconfig:/usr/share/pkgconfig --pkg-config-path /var/tmp/portage/gui-libs/gtk-4.19.0/temp/python3.12/pkgconfig:/usr/share/pkgconfig --native-file /var/tmp/portage/gui-libs/gtk-4.19.0/temp/meson.x86_64-pc-linux-gnu.amd64.ini -Db_pch=false -Dwerror=false -Dbuildtype=plain -Dx11-backend=true -Dwayland-backend=true -Dbroadway-backend=false -Dwin32-backend=false -Dmacos-backend=false -Dmedia-gstreamer=enabled -Dprint-cpdb=disabled -Dprint-cups=enabled -Dvulkan=enabled -Dcloudproviders=disabled -Dsysprof=disabled -Dtracker=disabled -Dcolord=enabled -Df16c=enabled -Dintrospection=enabled -Ddocumentation=false -Dscreenshots=false -Dman-pages=true -Dprofile=default -Dbuild-demos=false -Dbuild-testsuite=false -Dbuild-examples=false -Dbuild-tests=false /var/tmp/portage/gui-libs/gtk-4.19.0/work/gtk-4.19.0 /var/tmp/portage/gui-libs/gtk-4.19.0/work/gtk-4.19.0-build The Meson build system
Version: 1.8.0
Source dir: /var/tmp/portage/gui-libs/gtk-4.19.0/work/gtk-4.19.0 Build dir: /var/tmp/portage/gui-libs/gtk-4.19.0/work/gtk-4.19.0-build Build type: native build
Project name: gtk
Project version: 4.19.0
C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 14.2.1 "x86_64-pc-linux-gnu-gcc (Gentoo 14.2.1_p20241221 p7) 14.2.1 20241221") C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.44 Host machine cpu family: x86_64
Host machine cpu: x86_64
Has header "dev/evdev/input.h" : NO
Has header "ftw.h" : YES
Has header "linux/input.h" : YES
Has header "sys/mman.h" : YES
Has header "sys/sysmacros.h" : YES
Has header "sys/time.h" : YES
Has header "unistd.h" : YES
Library m found: YES
Checking for function "getpagesize" with dependency -lm: YES Checking for function "getresuid" with dependency -lm: YES Checking for function "madvise" with dependency -lm: YES Checking for function "memfd_create" with dependency -lm: YES Checking for function "mkostemp" with dependency -lm: YES Checking for function "mlock" with dependency -lm: YES Checking for function "mmap" with dependency -lm: YES Checking for function "posix_fallocate" with dependency -lm: YES Checking for function "sincos" with dependency -lm: YES Checking for function "sincosf" with dependency -lm: YES Checking for function "memmem" with dependency -lm: YES Checking if "sigsetjmp" links: YES
Checking if "__uint128_t available" compiles: YES
Compiler for C supports arguments -fno-strict-aliasing: YES Compiler for C supports arguments -Wno-c++11-extensions: NO Compiler for C supports arguments -Wno-missing-include-dirs: YES Compiler for C supports arguments -Wno-typedef-redefinition: NO Compiler for C supports arguments -Wno-tautological-constant-out-of-range-compare: NO Compiler for C supports arguments -Wduplicated-branches: YES Compiler for C supports arguments -Wduplicated-cond: YES Compiler for C supports arguments -Wformat=2: YES
Compiler for C supports arguments -Wformat-nonliteral: YES Compiler for C supports arguments -Wformat-security: YES Compiler for C supports arguments -Wignored-qualifiers: YES Compiler for C supports arguments -Wimplicit-function-declaration: YES Compiler for C supports arguments -Wlogical-op: YES Compiler for C supports arguments -Wmisleading-indentation: YES Compiler for C supports arguments -Wmissing-format-attribute: YES Compiler for C supports arguments -Wmissing-include-dirs: YES Compiler for C supports arguments -Wmissing-noreturn: YES Compiler for C supports arguments -Wnested-externs: YES Compiler for C supports arguments -Wold-style-definition: YES Compiler for C supports arguments -Wpointer-arith: YES Compiler for C supports arguments -Wshadow: YES
Compiler for C supports arguments -Wstrict-prototypes: YES Compiler for C supports arguments -Wswitch-default: YES Compiler for C supports arguments -Wswitch-enum: YES Compiler for C supports arguments -Wundef: YES
Compiler for C supports arguments -Wuninitialized: YES Compiler for C supports arguments -Wunused: YES
Compiler for C supports arguments -Waddress: YES
Compiler for C supports arguments -Warray-bounds: YES Compiler for C supports arguments -Wempty-body: YES Compiler for C supports arguments -Wenum-int-mismatch: YES Compiler for C supports arguments -Wimplicit: YES
Compiler for C supports arguments -Wimplicit-fallthrough: YES Compiler for C supports arguments -Wimplicit-fallthrough=5: YES Compiler for C supports arguments -Winit-self: YES Compiler for C supports arguments -Wint-to-pointer-cast: YES Compiler for C supports arguments -Wmain: YES
Compiler for C supports arguments -Wmissing-braces: YES Compiler for C supports arguments -Wmissing-declarations: YES Compiler for C supports arguments -Wmissing-prototypes: YES Compiler for C supports arguments -Wnonnull: YES
Compiler for C supports arguments -Woverride-init: YES Compiler for C supports arguments -Wpointer-to-int-cast: YES Compiler for C supports arguments -Wredundant-decls: YES Compiler for C supports arguments -Wreturn-type: YES Compiler for C supports arguments -Wsequence-point: YES Compiler for C supports arguments -Wtrigraphs: YES Compiler for C supports arguments -Wvla: YES
Compiler for C supports arguments -Wwrite-strings: YES Compiler for C supports arguments -Wcast-align: YES Compiler for C supports arguments -Wnull-dereference: YES Compiler for C supports arguments -fvisibility=hidden: YES Compiler for C supports link arguments -Wl,-Bsymbolic: YES Compiler for C supports link arguments -Wl,-z,relro: YES Compiler for C supports link arguments -Wl,-z,now: YES Found pkg-config: YES (/usr/bin/x86_64-pc-linux-gnu-pkg-config) 2.4.3 Run-time dependency glib-2.0 found: YES 2.82.5
Dependency gobject-introspection-1.0 found: NO. Found 1.82.0 but need: '>= 1.84' Found CMake: /usr/bin/cmake (3.31.5)
Run-time dependency gobject-introspection-1.0 found: NO (tried pkgconfig and cmake) Looking for a fallback subproject for the dependency gobject-introspection-1.0 ERROR: Subproject gobject-introspection is buildable: NO

meson.build:420:17: ERROR: Automatic wrap-based subproject downloading is disabled </pre>