### PR TITLE
gnome-base:gvfs Update deps

### DIFF
--- a/gnome-base/gvfs/gvfs-1.57.2.ebuild
+++ b/gnome-base/gvfs/gvfs-1.57.2.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
-	>=dev-libs/glib-2.70.0:2
+	>=dev-libs/glib-2.83.0:2
 	>=gnome-base/gsettings-desktop-schemas-3.33.0
 	afp? ( >=dev-libs/libgcrypt-1.2.2:0= )
 	sys-apps/dbus
@@ -52,7 +52,7 @@ RDEPEND="
 		>=app-pda/libimobiledevice-1.2:=
 		>=app-pda/libplist-1:=
 	)
-	gnome-online-accounts? ( >=net-libs/gnome-online-accounts-3.17.1:= )
+	gnome-online-accounts? ( >=net-libs/gnome-online-accounts-3.53.1:= )
 	keyring? ( app-crypt/libsecret )
 	bluray? ( media-libs/libbluray:= )
 	mtp? (


### PR DESCRIPTION
From /meson.build fix build

<pre>
>>> Configuring source in /var/tmp/portage/gnome-base/gvfs-1.57.2/work/gvfs-1.57.2 ...
meson setup -Db_lto=false --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc --wrap-mode nodownload --build.pkg-config-path /usr/share/pkgconfig --pkg-config-path /usr/share/pkgconfig --native-file /var/tmp/portage/gnome-base/gvfs-1.57.2/temp/meson.x86_64-pc-linux-gnu.amd64.ini -Db_pch=false -Dwerror=false -Dbuildtype=plain -Dsystemduserunitdir=/usr/lib/systemd/user -Dtmpfilesdir=/usr/lib/tmpfiles.d -Dadmin=true -Dafc=false -Dafp=false -Darchive=true -Dcdda=true -Ddnssd=true -Dgoa=true -Dgoogle=true -Dgphoto2=true -Dhttp=true -Dmtp=true -Dnfs=true -Dsftp=true -Dsmb=true -Dudisks2=true -Dbluray=false -Dfuse=true -Dgcr=true -Dgcrypt=false -Dgudev=true -Dkeyring=true -Dlogind=true -Dlibusb=true -Ddevel_utils=false -Dinstalled_tests=false -Dman=true -Donedrive=false -Dprivileged_group=wheel /var/tmp/portage/gnome-base/gvfs-1.57.2/work/gvfs-1.57.2 /var/tmp/portage/gnome-base/gvfs-1.57.2/work/gvfs-1.57.2-build The Meson build system
Version: 1.8.0
Source dir: /var/tmp/portage/gnome-base/gvfs-1.57.2/work/gvfs-1.57.2 Build dir: /var/tmp/portage/gnome-base/gvfs-1.57.2/work/gvfs-1.57.2-build Build type: native build
Project name: gvfs
Project version: 1.57.2
C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 14.2.1 "x86_64-pc-linux-gnu-gcc (Gentoo 14.2.1_p20241221 p7) 14.2.1 20241221") C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.44 Host machine cpu family: x86_64
Host machine cpu: x86_64
Checking for function "socketpair" : YES
Library util found: YES
Has header "util.h" with dependency -lutil: NO
Checking for function "openpty" with dependency -lutil: YES Checking for function "login_tty" with dependency -lutil: YES Has header "sys/param.h" : YES
Has header "sys/mount.h" : YES
Has header "sys/statfs.h" : YES
Has header "sys/statvfs.h" : YES
Has header "sys/vfs.h" : YES
Has header "stropts.h" : NO
Has header "sys/un.h" : YES
Has header "termios.h" : YES
Has header "utmp.h" : YES
Checking for function "getpt" : YES
Checking for function "grantpt" : YES
Checking for function "posix_openpt" : YES
Checking for function "ptsname" : YES
Checking for function "ptsname_r" : YES
Checking for function "unlockpt" : YES
Checking for function "statfs" : YES
Checking for function "statvfs" : YES
Header "langinfo.h" has symbol "_NL_ADDRESS_LANG_TERM" : YES Header "langinfo.h" has symbol "_NL_ADDRESS_COUNTRY_AB3" : YES Header "sys/mkdev.h" has symbol "major" : NO
Header "sys/sysmacros.h" has symbol "major" : YES
Header "sys/sysmacros.h" has symbol "minor" : YES
Header "sys/sysmacros.h" has symbol "makedev" : YES Checking for type "gid_t" : YES
Checking for type "pid_t" : YES
Checking for type "size_t" : YES
Checking for type "uid_t" : YES
Checking whether type "struct statfs" has members "f_bavail" : YES Checking whether type "struct statvfs" has members "f_basetype" : NO Checking whether type "struct stat" has members "st_atimensec" : NO Checking whether type "struct stat" has members "st_atim.tv_nsec" : YES Checking whether type "struct stat" has members "st_ctimensec" : NO Checking whether type "struct stat" has members "st_ctim.tv_nsec" : YES Checking whether type "struct stat" has members "st_mtimensec" : NO Checking whether type "struct stat" has members "st_mtim.tv_nsec" : YES Compiler for C supports link arguments -Wl,--version-script,/var/tmp/portage/gnome-base/gvfs-1.57.2/work/gvfs-1.57.2/client/symbol.map: YES Found pkg-config: YES (/usr/bin/x86_64-pc-linux-gnu-pkg-config) 2.4.3 Run-time dependency gio-2.0 found: YES 2.84.1
Run-time dependency gio-unix-2.0 found: YES 2.84.1 Run-time dependency glib-2.0 found: YES 2.84.1
Run-time dependency gobject-2.0 found: YES 2.84.1
Run-time dependency gsettings-desktop-schemas found: YES 48.0 Run-time dependency libxml-2.0 found: YES 2.13.7
Run-time dependency dbus-1 found: YES 1.16.2
Run-time dependency gcr-4 found: YES 4.2.1
Run-time dependency libcap found: YES 2.71
Run-time dependency polkit-gobject-1 found: YES 126 Run-time dependency libsoup-3.0 found: YES 3.4.4
Run-time dependency avahi-client found: YES 0.8
Run-time dependency avahi-glib found: YES 0.8
Run-time dependency gudev-1.0 found: YES 238
Run-time dependency fuse3 found: YES 3.17.2
Run-time dependency udisks2 found: YES 2.10.1
Run-time dependency libsystemd found: YES 256
Dependency goa-1.0 found: NO. Found 3.52.3.1 but need: '>= 3.53.1' Found CMake: /usr/bin/cmake (3.31.5)
Run-time dependency goa-1.0 found: NO (tried cmake)

meson.build:371:12: ERROR: Dependency lookup for goa-1.0 with method 'pkgconfig' failed: Invalid version, need 'goa-1.0' ['>= 3.53.1'] found '3.52.3.1'. </pre>